### PR TITLE
Ft unresolved checks dashboard 158174591

### DIFF
--- a/hc/front/tests/test_unresolved_checks.py
+++ b/hc/front/tests/test_unresolved_checks.py
@@ -2,6 +2,7 @@ from hc.api.models import Check
 from hc.test import BaseTestCase
 from datetime import timedelta as td
 from django.utils import timezone
+from django.urls import reverse
 
 
 class UnresolvedChecksTestCase(BaseTestCase):
@@ -16,7 +17,7 @@ class UnresolvedChecksTestCase(BaseTestCase):
         """Test the unresolved checks url works"""
 
         self.client.login(username="alice@example.org", password="password")
-        response = self.client.get("/unresolved_checks/")
+        response = self.client.get(reverse("hc-unresolved-checks"))
         self.assertEqual(response.status_code, 200)
 
     def test_grace_checks_not_returned(self):
@@ -27,7 +28,7 @@ class UnresolvedChecksTestCase(BaseTestCase):
         self.check.save()
 
         self.client.login(username="alice@example.org", password="password")
-        response = self.client.get("/unresolved_checks/")
+        response = self.client.get(reverse("hc-unresolved-checks"))
         self.assertNotIn("Alice", response)
 
     def test_only_unresolved_checks_are_returned(self):
@@ -38,7 +39,7 @@ class UnresolvedChecksTestCase(BaseTestCase):
         self.check.save()
 
         self.client.login(username="alice@example.org", password="password")
-        response = self.client.get("/unresolved_checks/")
+        response = self.client.get(reverse("hc-unresolved-checks"))
         self.assertContains(response, "Alice")
 
     def test_checks_up_not_returned(self):
@@ -49,5 +50,5 @@ class UnresolvedChecksTestCase(BaseTestCase):
         self.check.save()
 
         self.client.login(username="alice@example.org", password="password")
-        response = self.client.get("/unresolved_checks/")
+        response = self.client.get(reverse("hc-unresolved-checks"))
         self.assertNotIn("Alice", response)

--- a/hc/front/tests/test_unresolved_checks.py
+++ b/hc/front/tests/test_unresolved_checks.py
@@ -1,0 +1,53 @@
+from hc.api.models import Check
+from hc.test import BaseTestCase
+from datetime import timedelta as td
+from django.utils import timezone
+
+
+class UnresolvedChecksTestCase(BaseTestCase):
+    """class unresolved checks"""
+
+    def setUp(self):
+        super(UnresolvedChecksTestCase, self).setUp()
+        self.check = Check(user=self.alice, name="Alice")
+        self.check.save()
+
+    def test_unresolved_checks_url_works(self):
+        """Test the unresolved checks url works"""
+
+        self.client.login(username="alice@example.org", password="password")
+        response = self.client.get("/unresolved_checks/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_grace_checks_not_returned(self):
+        """Test checks with status grace are not returned"""
+
+        self.check.last_ping = timezone.now() - td(days=1, minutes=30)
+        self.check.status = "up"
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        response = self.client.get("/unresolved_checks/")
+        self.assertNotIn("Alice", response)
+
+    def test_only_unresolved_checks_are_returned(self):
+        """Test checks with status down are the only ones returned"""
+
+        self.check.last_ping = timezone.now() - td(days=3)
+        self.check.status = "down"
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        response = self.client.get("/unresolved_checks/")
+        self.assertContains(response, "Alice")
+
+    def test_checks_up_not_returned(self):
+        """Test checks with status up are not returned"""
+
+        self.check.last_ping = timezone.now()
+        self.check.status = "up"
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        response = self.client.get("/unresolved_checks/")
+        self.assertNotIn("Alice", response)

--- a/hc/front/tests/test_unresolved_checks.py
+++ b/hc/front/tests/test_unresolved_checks.py
@@ -33,7 +33,7 @@ class UnresolvedChecksTestCase(BaseTestCase):
     def test_only_unresolved_checks_are_returned(self):
         """Test checks with status down are the only ones returned"""
 
-        self.check.last_ping = timezone.now() - td(days=1)
+        self.check.last_ping = timezone.now() - td(days=3)
         self.check.status = "down"
         self.check.save()
 

--- a/hc/front/tests/test_unresolved_checks.py
+++ b/hc/front/tests/test_unresolved_checks.py
@@ -22,7 +22,7 @@ class UnresolvedChecksTestCase(BaseTestCase):
     def test_grace_checks_not_returned(self):
         """Test checks with status grace are not returned"""
 
-        self.check.last_ping = timezone.now() - td(days=1, minutes=30)
+        self.check.last_ping = timezone.now() - td(minutes=30)
         self.check.status = "up"
         self.check.save()
 
@@ -33,7 +33,7 @@ class UnresolvedChecksTestCase(BaseTestCase):
     def test_only_unresolved_checks_are_returned(self):
         """Test checks with status down are the only ones returned"""
 
-        self.check.last_ping = timezone.now() - td(days=3)
+        self.check.last_ping = timezone.now() - td(days=1)
         self.check.status = "down"
         self.check.save()
 

--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -40,6 +40,8 @@ urlpatterns = [
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),
     url(r'^reports/', views.reports, name="hc-reports"),
+    url(r'^unresolved_checks/', views.unresolved_checks,
+        name="hc-unresolved-checks"),
 
     url(r'^docs/$', views.docs, name="hc-docs"),
     url(r'^docs/api/$', views.docs_api, name="hc-docs-api"),

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -597,3 +597,26 @@ def privacy(request):
 
 def terms(request):
     return render(request, "front/terms.html", {})
+
+
+@login_required
+def unresolved_checks(request):
+    """function for unresolved jobs tab with jobs that are down"""
+    checks = list(
+        Check.objects.filter(
+            user=request.team.user).order_by("created"))
+    unresolved_checks = []
+
+    for check in checks:
+        status = check.get_status()
+        if status == "down":
+            unresolved_checks.append(check)
+
+    ctx = {
+        "page": "unresolved_checks",
+        "checks": unresolved_checks,
+        "now": timezone.now(),
+        "ping_endpoint": settings.PING_ENDPOINT
+    }
+
+    return render(request, "front/unresolved_checks.html", ctx)

--- a/templates/base.html
+++ b/templates/base.html
@@ -80,6 +80,10 @@
                         <a href="{% url 'hc-checks' %}">Checks</a>
                     </li>
 
+                    <li {% if page == 'unresolved_checks' %} class="active" {% endif %}>
+                        <a href="{% url 'hc-unresolved-checks' %}">Unresolved Checks</a>
+                    </li>
+
                     <li {% if page == 'channels' %} class="active" {% endif %}>
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>

--- a/templates/front/unresolved_checks.html
+++ b/templates/front/unresolved_checks.html
@@ -1,0 +1,320 @@
+{% extends "base.html" %}
+{% load compress staticfiles %}
+
+{% block title %}My Unresolved Checks - healthchecks.io{% endblock %}
+
+
+{% block content %}
+<div class="row">
+    <div class="col-sm-12">
+        <h1>
+        {% if request.team == request.user.profile %}
+            Unresolved Checks
+        {% else %}
+            {{ request.team.team_name }}
+        {% endif %}
+        </h1>
+    </div>
+    {% if tags %}
+    <div id="my-checks-tags" class="col-sm-12">
+        {% for tag, count in tags %}
+            {% if tag in down_tags %}
+                <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button>
+            {% elif tag in grace_tags %}
+                <button class="btn btn-warning btn-xs" data-toggle="button">{{ tag }}</button>
+            {% else %}
+                <button class="btn btn-default btn-xs" data-toggle="button">{{ tag }}</button>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
+</div>
+<div class="row">
+    <div class="col-sm-12">
+
+
+    {% if checks %}
+        {% include "front/my_checks_mobile.html" %}
+        {% include "front/my_checks_desktop.html" %}
+    {% else %}
+    <div class="alert alert-info">You don't have any unresolved checks yet.</div>
+    {% endif %}
+    </div>
+</div>
+<div id="update-name-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-name-form" class="form-horizontal" method="post">
+            {% csrf_token %}
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="update-timeout-title">Name and Tags</h4>
+                </div>
+                <div class="modal-body">
+                        <div class="form-group">
+                            <label for="update-name-input" class="col-sm-2 control-label">
+                                Name
+                            </label>
+                            <div class="col-sm-9">
+                                <input
+                                    id="update-name-input"
+                                    name="name"
+                                    type="text"
+                                    value="---"
+                                    placeholder="unnamed"
+                                    class="input-name form-control" />
+
+                                <span class="help-block">
+                                    Give this check a human-friendly name,
+                                    so you can easily recognize it later.
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="update-tags-input" class="col-sm-2 control-label">
+                                Tags
+                            </label>
+                            <div class="col-sm-9">
+                                <input
+                                    id="update-tags-input"
+                                    name="tags"
+                                    type="text"
+                                    value=""
+                                    placeholder="production www"
+                                    class="form-control" />
+
+                                <span class="help-block">
+                                    Optionally, assign tags for easy filtering.
+                                    Separate multiple tags with spaces.
+                                </span>
+                            </div>
+                        </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="update-timeout-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-timeout-form" method="post">
+            {% csrf_token %}
+            <input type="hidden" name="timeout" id="update-timeout-timeout" />
+            <input type="hidden" name="grace" id="update-timeout-grace" />
+            <div class="modal-content">
+                <div class="modal-body">
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="Expected time between pings.">
+                            Period
+                        </span>
+                        <span
+                            id="period-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+                    <div id="period-slider"></div>
+
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="When check is late, how much time to wait until alert is sent">
+                            Grace Time
+                        </span>
+                        <span
+                            id="grace-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+
+                    <div id="grace-slider"></div>
+
+                    <div class="update-timeout-terms">
+                        <p>
+                            <span>Period</span>
+                            Expected time between pings.
+                        </p>
+                        <p>
+                            <span>Grace Time</span>
+                            When a check is late, how much time to wait until alert is sent.
+                        </p>
+                    </div>
+
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="update-nag-interval-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-nag-interval-form" method="post">
+            {% csrf_token %}
+            <input type="hidden" name="nag_interval" id="update-timeout-timeout-2" />
+            <div class="modal-content">
+                <div class="modal-body">
+                    <div class="update-timeout-info text-center">
+                        <span class="update-timeout-label" data-toggle="tooltip" title="Expected time between pings.">
+                            Nag Interval
+                        </span>
+                        <span id="period-slider-value-2" class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+                    <div id="period-slider-2"></div>
+
+
+                    <div id="grace-slider"></div>
+
+                    <div class="update-timeout-terms">
+                        <p>
+                            <span>Period</span>
+                            Expected time between notificatons for job that is unresolved.
+                        </p>
+                    </div>
+
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="remove-check-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="remove-check-form" method="post">
+            {% csrf_token %}
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="remove-check-title">Remove Check
+                        <span class="remove-check-name"></span>
+                    </h4>
+                </div>
+                <div class="modal-body">
+                    <p>You are about to remove check
+                        <strong class="remove-check-name">---</strong>.
+                    </p>
+                    <p>Once it's gone there is no "undo" and you cannot get the old ping URL back.</p>
+                    <p>Are you sure?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Remove</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="show-usage-modal" class="modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <ul class="nav nav-pills" role="tablist">
+                    <li class="active">
+                        <a href="#crontab" data-toggle="tab">Crontab</a>
+                    </li>
+                    <li>
+                        <a href="#bash" data-toggle="tab">Bash</a>
+                    </li>
+                    <li>
+                        <a href="#python" data-toggle="tab">Python</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#node" data-toggle="tab">Node.js</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#php" data-toggle="tab">PHP</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#browser" data-toggle="tab">Browser</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#powershell" data-toggle="tab">PowerShell</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#email" data-toggle="tab">Email</a>
+                    </li>
+                </ul>
+
+            </div>
+            <div class="modal-body">
+
+
+                <div class="tab-content">
+                    {% with ping_url="<span class='ex'></span>" %}
+                    <div role="tabpanel" class="tab-pane active" id="crontab">
+                        {% include "front/snippets/crontab.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="bash">
+                        {% include "front/snippets/bash.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="python">
+                        {% include "front/snippets/python.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="node">
+                        {% include "front/snippets/node.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="php">
+                        {% include "front/snippets/php.html" %}
+                    </div>
+                    <div class="tab-pane" id="browser">
+                        {% include "front/snippets/browser.html" %}
+                    </div>
+                    <div class="tab-pane" id="powershell">
+                        {% include "front/snippets/powershell.html" %}
+                    </div>
+                    <div class="tab-pane" id="email">
+                            As an alternative to HTTP/HTTPS requests,
+                            you can "ping" this check by sending an
+                            email message to
+                            <div class="email-address">
+                                <code class="em"></code>
+                            </div>
+                    </div>
+                    {% endwith %}
+                </div>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Got It!</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<form id="pause-form" method="post">
+    {% csrf_token %}
+</form>
+
+{% endblock %}
+
+{% block scripts %}
+{% compress js %}
+<script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
+<script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script src="{% static 'js/nouislider.min.js' %}"></script>
+<script src="{% static 'js/clipboard.min.js' %}"></script>
+<script src="{% static 'js/checks.js' %}"></script>
+{% endcompress %}
+{% endblock %}


### PR DESCRIPTION
### What does this PR do?
Adds a new dashboard tab for unresolved checks i.e checks that are down.

### Description
 The user does not have a separate dashboard view of their failed jobs
This PR adds a new dashboard that has a listing of all the user's failed jobs which they have been notified about.

### How should this be manually tested?

- After cloning the repo, run the application ```./ manage.py runserver``` 

- Open the app in the browser, log in and add checks. 

- Make the checks fail and switch to the unresolved checks tab. 

- The failed checks should be listed there.

### What are the relevant pivotal tracker stories?
#158174591

Checklist:
  My code follows the style guidelines of this project
  I have performed a self-review of my own code
  I have commented my code
  My changes generate no new warnings

### Screenshots
![image](https://user-images.githubusercontent.com/31403932/42866080-3a7844f2-8a74-11e8-96e6-e5b640f6bb61.png)
